### PR TITLE
Corregir validación de Calendar y exponer dias_recurrencia en la API

### DIFF
--- a/calendarios/models.py
+++ b/calendarios/models.py
@@ -1,41 +1,32 @@
-from django.db import models
-from horarios.models import ProgramaFormacion, Ambiente, Competencia, Instructor
 from django.core.exceptions import ValidationError
+from django.db import models
+
+from horarios.models import Ambiente, Competencia, Instructor, ProgramaFormacion
+
 
 class Calendar(models.Model):
     instructor = models.ForeignKey(Instructor, on_delete=models.CASCADE)
     programa = models.ForeignKey(ProgramaFormacion, on_delete=models.CASCADE)
     ambiente = models.ForeignKey(Ambiente, on_delete=models.CASCADE)
     competencia = models.ForeignKey(Competencia, on_delete=models.CASCADE)
-    start = models.DateTimeField(null=True, blank=True, verbose_name="Inicio de la fromación")
+    start = models.DateTimeField(null=True, blank=True, verbose_name="Inicio de la formación")
     end = models.DateTimeField(null=True, blank=True, verbose_name="Fin de la formación")
-    dias_recurrencia = models.JSONField()  # Un campo JSON para almacenar los días de recurrencia (ej. ["lunes", "martes", "viernes"])
-
-    
-
-
+    dias_recurrencia = models.JSONField()
 
     class Meta:
         db_table = "calendar"
 
     def clean(self):
-        # Verificar que end sea mayor que la start
-        if self.end <= self.start:
-            raise ValidationError("La fecha y hora de finalización de la formación debe ser mayor que la fecha y hora de inicio.")
+        if self.start and self.end and self.end <= self.start:
+            raise ValidationError(
+                "La fecha y hora de finalización de la formación debe ser mayor que la fecha y hora de inicio."
+            )
 
     def __str__(self):
-        return f"{self.instructor.nombres} - {self.programa.nombre_programa} - {self.ambiente.nombre_ambiente} - {self.competencia.nombre}"
-
-    
-    @property
-    def nombres_instructor(self):
-        return self.instructor.nombres
-    
-    @property
-    def apellidos_instructor(self):
-        return self.instructor.apellidos
-    
-
+        return (
+            f"{self.instructor.nombres} - {self.programa.nombre_programa} - "
+            f"{self.ambiente.nombre_ambiente} - {self.competencia.nombre}"
+        )
 
     @property
     def nombres_instructor(self):

--- a/calendarios/serializers.py
+++ b/calendarios/serializers.py
@@ -21,6 +21,7 @@ class CalendarSerializer(serializers.ModelSerializer):
             'competencia',
             'start',
             'end',
+            'dias_recurrencia',
             'nombres_instructor',
             'apellidos_instructor',
             'codigo_programa',

--- a/calendarios/tests.py
+++ b/calendarios/tests.py
@@ -1,3 +1,117 @@
-from django.test import TestCase
+from datetime import timedelta
 
-# Create your tests here.
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone
+
+from calendarios.models import Calendar
+from calendarios.serializers import CalendarSerializer
+from horarios.models import Ambiente, Competencia, Instructor, ProgramaFormacion
+
+
+class CalendarModelTests(TestCase):
+    def setUp(self):
+        self.instructor = Instructor.objects.create(
+            nombres="Ana",
+            apellidos="Gomez",
+            correo_institucional="ana@sena.edu.co",
+            numero_celular="3000000000",
+            numero_cedula="123456",
+            competencias_imparte="Programación",
+        )
+        self.programa = ProgramaFormacion.objects.create(
+            codigo_programa="ADSO",
+            nombre_programa="Análisis y Desarrollo",
+            jornada=ProgramaFormacion.Jornada.MAÑANA,
+            numero_ficha="99999",
+            fecha_inicio=timezone.now().date(),
+            fecha_fin=timezone.now().date() + timedelta(days=30),
+        )
+        self.ambiente = Ambiente.objects.create(
+            codigo_ambiente="A1",
+            nombre_ambiente="Laboratorio 1",
+            sede=Ambiente.Sede.PRINCIPAL,
+        )
+        self.competencia = Competencia.objects.create(
+            nombre="Backend",
+            codigo_norma=1234,
+            unidad_competencia="Construcción de servicios web",
+            duracion_estimada="40",
+            resultado_aprendizaje="Implementar endpoints REST",
+        )
+
+    def test_calendar_clean_rejects_end_before_start(self):
+        start = timezone.now()
+        calendar = Calendar(
+            instructor=self.instructor,
+            programa=self.programa,
+            ambiente=self.ambiente,
+            competencia=self.competencia,
+            start=start,
+            end=start - timedelta(hours=1),
+            dias_recurrencia=["lunes", "martes"],
+        )
+
+        with self.assertRaises(ValidationError):
+            calendar.clean()
+
+    def test_calendar_clean_allows_null_dates(self):
+        calendar = Calendar(
+            instructor=self.instructor,
+            programa=self.programa,
+            ambiente=self.ambiente,
+            competencia=self.competencia,
+            start=None,
+            end=None,
+            dias_recurrencia=["jueves"],
+        )
+
+        calendar.clean()
+
+
+class CalendarSerializerTests(TestCase):
+    def setUp(self):
+        self.instructor = Instructor.objects.create(
+            nombres="Luis",
+            apellidos="Diaz",
+            correo_institucional="luis@sena.edu.co",
+            numero_celular="3111111111",
+            numero_cedula="654321",
+            competencias_imparte="Bases de datos",
+        )
+        self.programa = ProgramaFormacion.objects.create(
+            codigo_programa="TIC",
+            nombre_programa="Tecnologías de la Información",
+            jornada=ProgramaFormacion.Jornada.TARDE,
+            numero_ficha="77777",
+            fecha_inicio=timezone.now().date(),
+            fecha_fin=timezone.now().date() + timedelta(days=45),
+        )
+        self.ambiente = Ambiente.objects.create(
+            codigo_ambiente="B2",
+            nombre_ambiente="Aula TIC",
+            sede=Ambiente.Sede.ALTERNATIVA,
+        )
+        self.competencia = Competencia.objects.create(
+            nombre="SQL",
+            codigo_norma=5678,
+            unidad_competencia="Diseño de consultas",
+            duracion_estimada="20",
+            resultado_aprendizaje="Construir consultas optimizadas",
+        )
+
+    def test_serializer_exposes_dias_recurrencia(self):
+        calendar = Calendar.objects.create(
+            instructor=self.instructor,
+            programa=self.programa,
+            ambiente=self.ambiente,
+            competencia=self.competencia,
+            start=timezone.now(),
+            end=timezone.now() + timedelta(hours=2),
+            dias_recurrencia=["lunes", "viernes"],
+        )
+
+        data = CalendarSerializer(calendar).data
+
+        self.assertIn("dias_recurrencia", data)
+        self.assertEqual(data["dias_recurrencia"], ["lunes", "viernes"])


### PR DESCRIPTION
### Motivation
- Evitar errores cuando `start` o `end` estén nulos en el modelo `Calendar` y mantener la validación de rango solo cuando ambas fechas existen.
- Garantizar que los días de recurrencia no se pierdan en las respuestas de la API incluyendo `dias_recurrencia` en el serializador.
- Añadir pruebas para cubrir los casos de validación de fechas y la serialización de `dias_recurrencia`.

### Description
- Cambiada la validación en `Calendar.clean()` para únicamente comparar fechas cuando `self.start` y `self.end` están presentes (`if self.start and self.end and self.end <= self.start:`). 
- Eliminadas definiciones duplicadas y se corrigió el `verbose_name` (corrección ortográfica) en `calendarios/models.py` para dejar el modelo más consistente.
- Agregado `dias_recurrencia` a `CalendarSerializer` para que el campo JSON sea parte de los `fields` expuestos por la API.
- Añadido `calendarios/tests.py` con pruebas que verifican la validación cuando `end < start`, la tolerancia a fechas nulas y que la serialización incluye `dias_recurrencia`.

### Testing
- Ejecutado `python manage.py test calendarios` que corrió 3 pruebas y pasó correctamente (`Ran 3 tests ... OK`).
- Ejecutado `python manage.py check` que no reportó problemas (`System check identified no issues`).
- Ejecutado `python manage.py test` a nivel global en este entorno que no descubrió tests adicionales y finalizó sin errores (0 tests descubiertos).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698560e8fcb48330a997ae18e69ef1d8)